### PR TITLE
Use secure Supabase RPC to load team profiles

### DIFF
--- a/src/services/profiles.ts
+++ b/src/services/profiles.ts
@@ -1,0 +1,30 @@
+const roleLabel: Record<string, string> = {
+  admin: 'Admin',
+  manager: 'Gerente',
+  collaborator: 'Colaborador',
+  client: 'Cliente',
+  member: 'Membro',
+  viewer: 'Visualizador',
+};
+
+const statusLabel: Record<string, string> = {
+  active: 'Ativo',
+  inactive: 'Inativo',
+  pending: 'Pendente',
+  invited: 'Convidado',
+  suspended: 'Suspenso',
+  blocked: 'Bloqueado',
+};
+
+export async function loadTeam(supabase: any) {
+  const { data, error } = await supabase.rpc('get_all_profiles_secure');
+  if (error) throw error;
+  return (data ?? []).map((p: any) => ({
+    ...p,
+    roleLabel: roleLabel[p.role] ?? p.role,
+    statusLabel: statusLabel[p.status] ?? p.status,
+  }));
+}
+
+export type LoadTeamResult = Awaited<ReturnType<typeof loadTeam>>;
+export type TeamMember = LoadTeamResult extends (infer U)[] ? U : never;


### PR DESCRIPTION
## Summary
- add a dedicated team service that calls the secure `get_all_profiles_secure` RPC and maps role/status labels
- update the users context to load profiles through the new service and persist both raw values and human-friendly labels

## Testing
- npm run lint *(fails: ESLint configuration missing in repository)*

------
https://chatgpt.com/codex/tasks/task_b_68da68cf6f4c832a809b1dc917339001